### PR TITLE
Resolves import failure when vm.guest.net object is null

### DIFF
--- a/src/collectors/vm_collector.py
+++ b/src/collectors/vm_collector.py
@@ -257,6 +257,7 @@ class VMCollector:
             
         Returns:
             list: List of dictionaries with network properties for each NIC
+            None: If vm.guest.net is not found
         """
         network_properties_list = []
         
@@ -299,14 +300,7 @@ class VMCollector:
         
         # If no NICs were found, add a single entry with just the VM name
         if not network_properties_list:
-            network_properties_list.append({
-                "VM": vm.name,
-                "Network": "",
-                "IPv4 Address": "",
-                "IPv6 Address": "",
-                "Switch": "",
-                "Mac Address": ""
-            })
+            return None
         
         return network_properties_list
     

--- a/src/vcenter_orchestrator.py
+++ b/src/vcenter_orchestrator.py
@@ -132,11 +132,16 @@ class VCenterOrchestrator:
                     if self.vm_collector._is_duplicate_uuid(vm_properties):
                         continue
                     
-                    vm_data["vm_info"].append(vm_properties)
-                
                     # Get VM network properties
                     vm_network_properties = self.vm_collector.get_vm_network_properties(vm)
+                    if vm_network_properties is None:
+                        print(f"Skipping VM {vm.name} (no network properties found)")
+                        continue
+
                     vm_data["vm_network"].extend(vm_network_properties)
+
+                    # Moved this below vm_network_properties, if the properties returns nothing we want to skip the VM
+                    vm_data["vm_info"].append(vm_properties)
                     
                     # Get VM CPU properties
                     vm_cpu_properties = self.vm_collector.get_vm_cpu_properties(vm)

--- a/test/test_unit_vm_collector.py
+++ b/test/test_unit_vm_collector.py
@@ -550,11 +550,7 @@ class TestVMCollector:
         
         network_props = vm_collector.get_vm_network_properties(mock_vm)
         
-        assert len(network_props) == 1
-        assert network_props[0]["VM"] == "test-vm-no-nics"
-        assert network_props[0]["Network"] == ""
-        assert network_props[0]["IPv4 Address"] == ""
-        assert network_props[0]["Switch"] == ""
+        assert network_props is None
     
     def test_get_vm_disk_properties_no_disks(self, vm_collector):
         """Test disk properties when VM has no disks"""


### PR DESCRIPTION
Closes #14 

If vm.guest.net property returns null, script will now skip the VM
